### PR TITLE
Revert key

### DIFF
--- a/lib/circle_nav_bar.dart
+++ b/lib/circle_nav_bar.dart
@@ -42,6 +42,7 @@ class CircleNavBar extends StatefulWidget {
   ///
   /// ![](doc/value-05.png)
   const CircleNavBar({
+    super.key,
     required this.activeIndex,
     this.onTap,
     this.tabCurve = Curves.linearToEaseOut,


### PR DESCRIPTION
Although key was removed from the constructor in #5, the widget constructor should have a parameter named `key`.
